### PR TITLE
feat: allow using yaml files as input

### DIFF
--- a/bin/getNamespaces.js
+++ b/bin/getNamespaces.js
@@ -1,10 +1,17 @@
 const fs = require('fs')
 const path = require('path')
+const YAML = require('yaml')
+
+const parsers = {
+  '.json': JSON.parse,
+  '.yml': YAML.parse,
+  '.yaml': YAML.parse
+}
 
 const getFiles = (srcpath) => {
   return fs.readdirSync(srcpath).filter((file) => {
     return !fs.statSync(path.join(srcpath, file)).isDirectory()
-  }).filter((file) => path.extname(file) === '.json').map((file) => path.join(srcpath, file))
+  }).filter((file) => Object.keys(parsers).includes(path.extname(file))).map((file) => path.join(srcpath, file))
 }
 
 const getDirectories = (srcpath) => {
@@ -26,7 +33,8 @@ module.exports = (p) => {
   const allFiles = getAllFiles(p)
 
   return allFiles.map((file) => {
-    const namespace = JSON.parse(fs.readFileSync(file, 'utf-8'))
+    const parse = parsers[path.extname(file)]
+    const namespace = parse(fs.readFileSync(file, 'utf-8'))
     const sepFile = file.split(path.sep)
     const fileName = sepFile[sepFile.length - 1]
     const name = path.parse(fileName).name

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.23.2"
+    "@babel/runtime": "^7.23.2",
+    "yaml": "^2.3.4"
   },
   "devDependencies": {
     "@babel/core": "^7.23.3",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included (**Did not find other tests for the cli part**)
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

This PR adds support for parsing YAML files to bring the tool in-line with the i18next-parser [which supports outputting YAML](https://arc.net/l/quote/xmaptada)