### PR TITLE
Fix interface cmd destination file validation

### DIFF
--- a/bin/i18next-resources-for-ts.js
+++ b/bin/i18next-resources-for-ts.js
@@ -89,10 +89,10 @@ if (subCommand === 'merge') {
 
 if (subCommand === 'interface') {
   let outputFile = outputPath
-  if (!outputFile.endsWith('.d.ts')) {
+  if (!outputFile.endsWith('.ts')) {
     outputFile = path.join(outputFile, 'resources.d.ts')
   }
   const typeDefinitionFile = mergeResourcesAsInterface(namespaces)
   fs.writeFileSync(outputFile, commentSection + typeDefinitionFile, 'utf-8')
-  console.log(`created .d.ts resources file for ${namespaces.length} namespaces: ${outputFile}`)
+  console.log(`created interface resources file for ${namespaces.length} namespaces: ${outputFile}`)
 }


### PR DESCRIPTION
**Why this fix?** I'm using this library and faced a problem. I'm using it in a private library for other project. This private library is used to configurate I18Next common configs and automatically load common JSON translation files. To do that I use this library to convert those translation files to an interface and I want my typescript compiler to include this Resources interface in my output folder for publishing purpose.

**Here's the problem.** The typescript compiler doesn't compile ".d.ts" files. It needs to be a ".ts" file. Normally it would not pose a problem in a normal utilisation. My current workaround is to execute the command two times. One before the build in my src folder and another in my dist folder after the build but it's not a something I wish to keep in the long run.

**Here's my proposed solution.** I propose to let the user choose to output the interface command in a ".ts" file. It will let the library be able to handle edge case while still recommand the use of ".d.ts" file.

No changes affect tests.