### PR TITLE
Stringify string resource instead of applying str.replace to preserve newlines

### DIFF
--- a/src/mergeResourcesAsInterface.js
+++ b/src/mergeResourcesAsInterface.js
@@ -15,7 +15,7 @@ function mergeResourcesAsInterface (namespaces, options = {}) {
 
 function resourceToString (resources, indentation = 0) {
   const intend = '  '.repeat(indentation)
-  if (typeof resources === 'string') return `"${resources.replace(/"/g, '\\"')}"`
+  if (typeof resources === 'string') return JSON.stringify(resources)
   if (Array.isArray(resources)) {
     return `[${resources.map(it => resourceToString(it)).join(', ')}]`
   }


### PR DESCRIPTION
Fixes https://github.com/i18next/i18next-resources-for-ts/issues/8
Sadly I was unable to write a test case that actually failed before this fix. The inputs are all in line with the test cases @adrai has written regarding newline checks. Yet they still broke in a live project.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)